### PR TITLE
Update arc_mapping.py to have name spaces more directly corresponding to ISA specs

### DIFF
--- a/src/omero_arc/arc_mapping.py
+++ b/src/omero_arc/arc_mapping.py
@@ -240,7 +240,7 @@ class IsaStudyMapper(AbstractIsaMapper):
         # annotation
         self.isa_attribute_config = {
             "metadata": {
-                "namespace": "ARC:ISA:STUDY:STUDY METADATA",
+                "namespace": "ARC:ISA:STUDY:STUDY",
                 "default_values": {
                     "Study Identifier": ome_project.getName().lower().replace(" ", "-"),
                     "Study Title": ome_project.getName(),
@@ -451,7 +451,7 @@ class IsaAssayMapper(AbstractIsaMapper):
 
         self.isa_attribute_config = {
             "metadata": {
-                "namespace": "ARC:ISA:ASSAY:ASSAY METADATA",
+                "namespace": "ARC:ISA:ASSAY:ASSAY",
                 "default_values": {
                     "Assay Identifier": ome_dataset.getName().lower().replace(" ", "-"),
                     "Measurement Type": None,

--- a/test/abstract_arc_test.py
+++ b/test/abstract_arc_test.py
@@ -150,7 +150,7 @@ class AbstractArcTest(AbstractCLITest):
     def dataset_with_arc_assay_annotation(self):
         dataset = self.make_dataset(name="My Assay with Annotations")
 
-        annotation_namespace = "ARC:ISA:ASSAY:ASSAY METADATA"
+        annotation_namespace = "ARC:ISA:ASSAY:ASSAY"
         annotations = {
             "Assay Identifier": "my-custom-assay-id",
             "Measurement Type": ("High resolution transmission electron micrograph"),
@@ -372,7 +372,7 @@ class AbstractArcTest(AbstractCLITest):
             parent_object=project,
         )
 
-        annotation_namespace = "ARC:ISA:STUDY:STUDY METADATA"
+        annotation_namespace = "ARC:ISA:STUDY:STUDY"
         annotations = {
             "Study Identifier": "my-custom-study-id",
             "Study Title": "My Custom Study Title",


### PR DESCRIPTION
Changed the name of an assay namespace to comply with the ISA subsection name, i.e."ARC:ISA:ASSAY:ASSAY METADATA" to "ARC:ISA:ASSAY:ASSAY" and "ARC:ISA:STUDY:STUDY METADATA" to "ARC:ISA:STUDY:STUDY".